### PR TITLE
Enhancement/limit shown rows in react table

### DIFF
--- a/src/components/DatasetTableWrapper/DatasetTable/DatasetTable.jsx
+++ b/src/components/DatasetTableWrapper/DatasetTable/DatasetTable.jsx
@@ -2,11 +2,14 @@
 import React, { useState, useEffect } from 'react';
 import ReactTable from 'react-table';
 import { Select } from 'nav-frontend-skjema';
+import { ToggleKnapp } from 'nav-frontend-toggle';
 import HandleTypeSelect from '../../../util/handleTypeSelect';
 import 'react-table/react-table.css';
 
 const DatasetTable = React.memo(({ dataset, attributes, setAttributes }) => {
   const [defaultTypes, setDefaultTypes] = useState(attributes.map(attr => attr.attributeTypeModel));
+  const [showAll, setShowAllData] = useState(false);
+
   useEffect(() => {
     setDefaultTypes(attributes.map(attr => attr.attributeTypeModel));
   }, [attributes]);
@@ -46,10 +49,15 @@ const DatasetTable = React.memo(({ dataset, attributes, setAttributes }) => {
     width: 164,
   }));
 
-  const data = dataset.slice(1);
+  const data = showAll ? dataset.slice(1) : dataset.slice(1, 100);
 
   const content = (
     <div className="dataset-table">
+      <ToggleKnapp
+        onClick={(e, pressed) => setShowAllData(pressed)}
+      >
+        Show all rows
+      </ToggleKnapp>
       <ReactTable
         data={data}
         columns={columns}

--- a/src/components/NavbarMain/MoreInfoButton/__test__/MoreInfoButton.test.jsx
+++ b/src/components/NavbarMain/MoreInfoButton/__test__/MoreInfoButton.test.jsx
@@ -13,11 +13,12 @@ describe('test for MoreInfo button', () => {
   });
 
   it('Test button state change', () => {
+    const moreInfoText = (<h1>Information</h1>);
     const app = mount(<App />);
-    expect(app.contains(<h1>Information</h1>)).toEqual(false);
+    expect(app.contains(moreInfoText)).toEqual(false);
     app.find('ToggleKnapp').simulate('click');
-    expect(app.contains(<h1>Information</h1>)).toEqual(true);
+    expect(app.contains(moreInfoText)).toEqual(true);
     app.find('ToggleKnapp').simulate('click');
-    expect(app.contains(<h1>Information</h1>)).toEqual(false);
+    expect(app.contains(moreInfoText)).toEqual(false);
   });
 });


### PR DESCRIPTION
Legger til en toggle knapp for å vise alle radene i datasettet, og lar tabellen bare vise de første 100 by default. 
Dette er bare ett forslag så vi får ta eventuelle endringer på mandag.
Personlig så mener jeg at nettsiden vil virke laggy for brukerne ved større dataset om vi ikke begrenser mengden data react-table laster inn.